### PR TITLE
ci: migrate all GitHub workflows to use self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/wiki-deploy.yml
+++ b/.github/workflows/wiki-deploy.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   publish-wiki:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - uses: actions/checkout@v4
       


### PR DESCRIPTION
Uses self-hosted runners instead of ubuntu-latest