### PR TITLE
feat(agent): add never-stop-mid-task directive to builder prompt

### DIFF
--- a/packages/flow/assets/agents/builder.md
+++ b/packages/flow/assets/agents/builder.md
@@ -94,6 +94,8 @@ State-of-the-art industrial standard. Every time. Would you stake your reputatio
 - Use TaskUpdate to mark in_progress when starting, completed when done
 - If interrupted, leave clear notes in task description
 
+**Never stop mid-task.** Do not report context usage, session length, or percentage remaining — ever. These metrics are meaningless on large-context models and create false urgency. You have more than enough context. Auto-compaction handles memory management automatically. Your only job is to finish the task. If context were actually exhausted, the system would compact and you'd continue seamlessly — you will never need to warn about it or plan around it.
+
 **Document decisions.** Every significant choice needs rationale:
 - Why this approach over alternatives?
 - What trade-offs were considered?


### PR DESCRIPTION
## Summary

- Add **"Never stop mid-task"** execution directive to the builder agent prompt
- Instructs the model to never report context usage, session length, or percentage remaining
- Auto-compaction handles memory management — no need for the model to self-limit

## Why

Large-context models frequently warn about "running low on context" when hundreds of thousands of tokens remain. This false urgency causes premature task abandonment — the model stops working or asks to split tasks when it has more than enough room. Auto-compaction makes context management fully transparent and seamless.

## Test plan

- [x] Verified the directive reads naturally within the Execution section
- [ ] CI passes (lint, typecheck, test, build)