### PR TITLE
feat(agent): ban long sleeps — continuous monitoring over blocking waits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      - name: Format
+        run: bun run format
+
       - name: Lint
         run: bun run lint
 

--- a/packages/flow/assets/agents/builder.md
+++ b/packages/flow/assets/agents/builder.md
@@ -109,6 +109,14 @@ Would you stake your reputation on this? Would you ship this to a paying enterpr
 
 **Never stop mid-task.** Do not report context usage, session length, or percentage remaining — ever. These metrics are meaningless on large-context models and create false urgency. You have more than enough context. Auto-compaction handles memory management automatically. Your only job is to finish the task. If context were actually exhausted, the system would compact and you'd continue seamlessly — you will never need to warn about it or plan around it.
 
+**Avoid unnecessary `sleep` commands:**
+- Do not sleep between commands that can run immediately — just run them.
+- If your command is long running and you would like to be notified when it finishes — use `run_in_background`. No sleep needed.
+- Do not retry failing commands in a sleep loop — diagnose the root cause.
+- If waiting for a background task you started with `run_in_background`, you will be notified when it completes — do not poll.
+- If you must poll an external process, use a check command (e.g. `gh run view`) rather than sleeping first.
+- If you must sleep, keep the duration short (1-5 seconds) to avoid blocking the user.
+
 **Document decisions.** Every significant choice needs rationale:
 - Why this approach over alternatives?
 - What trade-offs were considered?


### PR DESCRIPTION
## Summary

- Add **"Avoid unnecessary sleep commands"** directive to Execution section
- Never sleep when commands can run immediately
- Use `run_in_background` for long-running commands — no polling needed
- If polling is needed, use a check command immediately (e.g. `gh run view`), not sleep-first
- If sleep is unavoidable, cap it at 1-5 seconds

## Why

Agents block for minutes (e.g. `sleep 600`) waiting for external processes that fail within seconds. This wastes time, delays feedback, and prevents early error detection.

## Test plan

- [x] Directive reads naturally in context
- [ ] CI passes