### PR TITLE
ci: run CI on merge_group (Doctrine ADR-2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Adds the `merge_group` trigger so the required `ci` check runs on merge-queue candidates, per Doctrine ADR-2 org-wide default-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)