### PR TITLE
chore: remove @sylphx/doctor (retired checker)

### DIFF
--- a/README.md
+++ b/README.md
@@ -920,7 +920,6 @@ MIT License - see [LICENSE](LICENSE) file for details.
 
 - [@sylphx/biome-config](https://www.npmjs.com/package/@sylphx/biome-config)
 - [@sylphx/bump](https://www.npmjs.com/package/@sylphx/bump)
-- [@sylphx/doctor](https://www.npmjs.com/package/@sylphx/doctor)
 
 ---
 

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,6 @@
         "@biomejs/biome": "^2.4.14",
         "@sylphx/biome-config": "^0.4.1",
         "@sylphx/bump": "^1.6.1",
-        "@sylphx/doctor": "^1.34.0",
         "@types/bun": "^1.3.13",
         "@types/debug": "^4.1.13",
         "@types/node": "^24.12.3",
@@ -32,7 +31,7 @@
     },
     "packages/flow": {
       "name": "@sylphx/flow",
-      "version": "3.29.1",
+      "version": "3.30.0",
       "bin": {
         "sylphx-flow": "./src/index.ts",
         "flow": "./src/index.ts",
@@ -380,8 +379,6 @@
     "@sylphx/biome-config": ["@sylphx/biome-config@0.4.1", "", { "peerDependencies": { "@biomejs/biome": "^2.0.0" } }, "sha512-yNdrXKcnhrXK+OB2WLEJix6cryj3PME5DbKpGFMJGA6/B1/+mpk2ChKiohifrf956FKQ3JTAqhLhZfY7lu18yA=="],
 
     "@sylphx/bump": ["@sylphx/bump@1.6.1", "", { "dependencies": { "citty": "^0.1.6", "consola": "^3.4.2", "defu": "^6.1.4", "picocolors": "^1.1.1", "semver": "^7.6.3", "zx": "^8.8.5" }, "bin": { "bump": "dist/cli.js" } }, "sha512-Dp0RVzTd74sfslN1ilgYofJYkezdbF2EogyFZuy1drMSRgQ0qquhNyNkSFOoEgZWhRl91G3scC5E5DmqwLaUiA=="],
-
-    "@sylphx/doctor": ["@sylphx/doctor@1.34.0", "", { "dependencies": { "citty": "^0.1.6", "consola": "^3.4.2", "defu": "^6.1.4", "jiti": "^2.4.2", "picocolors": "^1.1.1" }, "bin": { "doctor": "dist/cli.js" } }, "sha512-0ZXoO/7oRUSZhF3EtFYLCJJJf+EeDt9hP4x26jAyfHnyJLPd5dqJlhXrl8OL+n1ZNOUvVGigfJRR/7UBL2n88w=="],
 
     "@sylphx/flow": ["@sylphx/flow@workspace:packages/flow"],
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,4 +1,3 @@
-# Managed by @sylphx/doctor
 # https://github.com/evilmartians/lefthook
 
 pre-commit:
@@ -12,11 +11,3 @@ pre-commit:
     lint:
       glob: "*.{js,ts,jsx,tsx}"
       run: bunx biome check {staged_files}
-
-    doctor:
-      run: bunx @sylphx/doctor check --pre-commit
-
-pre-push:
-  commands:
-    doctor:
-      run: bunx @sylphx/doctor check --pre-push

--- a/package.json
+++ b/package.json
@@ -51,8 +51,7 @@
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "turbo run build && changeset publish",
-    "typecheck": "turbo typecheck",
-    "prepublishOnly": "bunx @sylphx/doctor prepublish"
+    "typecheck": "turbo typecheck"
   },
   "engines": {
     "node": ">=18.0.0"
@@ -73,7 +72,6 @@
     "@biomejs/biome": "^2.4.14",
     "@sylphx/biome-config": "^0.4.1",
     "@sylphx/bump": "^1.6.1",
-    "@sylphx/doctor": "^1.34.0",
     "@types/bun": "^1.3.13",
     "@types/debug": "^4.1.13",
     "@types/node": "^24.12.3",


### PR DESCRIPTION
Removes the retired @sylphx/doctor standards checker (devDependency, doctor scripts, doctor-managed lefthook hooks). Lockfile updated; CHANGELOG history untouched. Part of the org-wide doctor retirement.