### PR TITLE
ci: add ADR-29 postsubmit recovery gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,40 @@ jobs:
           mode: fan-in
           policy-mode: observe
           upstream-results-json: ${{ toJSON(needs) }}
+
+  postsubmit-proof:
+    name: postsubmit-proof/pass
+    runs-on: ubuntu-latest
+    needs:
+      - risk-classification
+      - ci
+      - trunk-admission
+    if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && !cancelled() }}
+    steps:
+      - name: ADR-29 postsubmit proof
+        uses: SylphxAI/.github/.github/actions/adr29-admission@main
+        with:
+          mode: postsubmit-proof
+          policy-mode: enforce
+          upstream-results-json: ${{ toJSON(needs) }}
+
+  recovery-decision:
+    name: recovery-decision/pass
+    runs-on: ubuntu-latest
+    needs:
+      - risk-classification
+      - ci
+      - trunk-admission
+      - postsubmit-proof
+    if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.postsubmit-proof.result != 'success' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: ADR-29 recovery decision
+        uses: SylphxAI/.github/.github/actions/adr29-admission@main
+        with:
+          mode: recovery-decision
+          policy-mode: observe
+          upstream-results-json: ${{ toJSON(needs) }}


### PR DESCRIPTION
## Summary
- add `postsubmit-proof/pass` on `push` to `main`, fanning in `risk-classification`, raw `ci`, and `trunk-admission`
- add conditional `recovery-decision/pass` so a failed postsubmit proof still produces a structured ADR-29 recovery decision

## Validation
- YAML parse of `.github/workflows/ci.yml`
- `actionlint` on `.github/workflows/ci.yml`
- `git diff --check`
- doctrine audit on this branch: `postsubmit_recovery_status=PRESENT`

## Risk
CI/governance-only. `postsubmit-proof/pass` runs only on `push` to `main`; PR/merge queue required contexts remain `risk-classification/pass` and `trunk-admission/pass`.