### PR TITLE
docs: adopt doctrine project manifest

### DIFF
--- a/.doctrine/project.json
+++ b/.doctrine/project.json
@@ -97,26 +97,17 @@
   },
   "delivery": {
     "ciModel": "adr29-admission",
-    "requiredContexts": [
-      "risk-classification/pass",
-      "trunk-admission/pass"
-    ],
+    "requiredContexts": ["risk-classification/pass", "trunk-admission/pass"],
     "deployPath": "Central reusable release workflow publishes the @sylphx/flow package from main release intent.",
     "productionProof": "Admission contexts, CI fan-in/postsubmit proof, npm package readback, projection smoke tests, and docs readback.",
     "recoveryClass": "forward-fix-only",
     "packageRelease": {
       "publishesPackages": true,
-      "ecosystems": [
-        "npm",
-        "changesets"
-      ],
+      "ecosystems": ["npm", "changesets"],
       "releaseIntent": "Changesets capture package release intent and the reusable release workflow publishes changed packages.",
       "versionPr": "Version PR and changelog changes are produced by the reusable release workflow.",
       "publisher": "SylphxAI/.github reusable release workflow with inherited repository secrets.",
-      "requiredContexts": [
-        "risk-classification/pass",
-        "trunk-admission/pass"
-      ],
+      "requiredContexts": ["risk-classification/pass", "trunk-admission/pass"],
       "publishProof": "npm package readback for @sylphx/flow plus projection smoke evidence."
     }
   },

--- a/.doctrine/project.json
+++ b/.doctrine/project.json
@@ -1,0 +1,140 @@
+{
+  "schemaVersion": 1,
+  "project": {
+    "repo": "SylphxAI/flow",
+    "name": "Flow",
+    "lifecycle": "production",
+    "layer": "tooling",
+    "summary": "Flow is a production agent-tooling repository for canonical Sylphx agent assets, runtime projections, and the @sylphx/flow CLI.",
+    "goals": [
+      "Own canonical agent assets under packages/flow/assets/.",
+      "Own the Flow CLI, runtime projection logic, docs, package release workflow, and admission workflow.",
+      "Keep agent identity, standards, and skills single-sourced and projected into runtime-specific layouts without creating prompt islands."
+    ],
+    "nonGoals": [
+      "Own individual product repos' local project facts, deployment paths, or customer-specific behavior.",
+      "Duplicate Builder identity, standards, or skills in runtime-specific directories.",
+      "Treat source revert as complete recovery after package publish or agent-runtime projection behavior is released."
+    ]
+  },
+  "boundaries": {
+    "owns": [
+      {
+        "name": "canonical-agent-assets",
+        "description": "Agent identities, standards, skills, and reusable assets under packages/flow/assets/."
+      },
+      {
+        "name": "runtime-projections",
+        "description": "Flow CLI logic that projects canonical assets into supported AI coding-tool runtime layouts."
+      }
+    ],
+    "doesNotOwn": [
+      "Individual product repos' local project facts, deployment paths, or customer-specific behavior.",
+      "Enterprise doctrine repository content unless explicitly imported as a public dependency.",
+      "Third-party AI coding tools outside Flow's documented projection adapters."
+    ],
+    "publicSurfaces": [
+      {
+        "type": "package-export",
+        "name": "@sylphx/flow CLI package",
+        "location": "packages/flow/package.json"
+      },
+      {
+        "type": "documentation",
+        "name": "Canonical agent asset docs",
+        "location": "packages/flow/assets/"
+      },
+      {
+        "type": "workflow",
+        "name": "ADR-29 admission workflow",
+        "location": ".github/workflows/ci.yml"
+      },
+      {
+        "type": "status-context",
+        "name": "Required branch contexts",
+        "location": "risk-classification/pass, trunk-admission/pass"
+      }
+    ],
+    "allowedDependencies": [
+      {
+        "repo": "SylphxAI/doctrine",
+        "surface": "enterprise engineering doctrine",
+        "direction": "downward"
+      },
+      {
+        "repo": "SylphxAI/.github",
+        "surface": "ADR-29 admission action and reusable release workflow",
+        "direction": "downward"
+      }
+    ],
+    "forbiddenCouplings": [
+      "Do not create runtime-specific prompt islands that duplicate canonical Flow assets.",
+      "Do not add product-specific behavior to canonical agent identity, standards, or skills without a documented public extension point.",
+      "Do not publish package/projection behavior without release proof and projection smoke tests."
+    ]
+  },
+  "documentation": {
+    "adr": {
+      "path": "docs/adr/",
+      "status": "present"
+    },
+    "specs": {
+      "path": "README.md",
+      "status": "present"
+    },
+    "catalog": {
+      "path": "PROJECT.md",
+      "status": "present"
+    },
+    "runbooks": {
+      "path": "AGENTS.md",
+      "status": "present"
+    },
+    "generatedReferences": {
+      "path": "packages/flow/dist/",
+      "status": "generated"
+    }
+  },
+  "delivery": {
+    "ciModel": "adr29-admission",
+    "requiredContexts": [
+      "risk-classification/pass",
+      "trunk-admission/pass"
+    ],
+    "deployPath": "Central reusable release workflow publishes the @sylphx/flow package from main release intent.",
+    "productionProof": "Admission contexts, CI fan-in/postsubmit proof, npm package readback, projection smoke tests, and docs readback.",
+    "recoveryClass": "forward-fix-only",
+    "packageRelease": {
+      "publishesPackages": true,
+      "ecosystems": [
+        "npm",
+        "changesets"
+      ],
+      "releaseIntent": "Changesets capture package release intent and the reusable release workflow publishes changed packages.",
+      "versionPr": "Version PR and changelog changes are produced by the reusable release workflow.",
+      "publisher": "SylphxAI/.github reusable release workflow with inherited repository secrets.",
+      "requiredContexts": [
+        "risk-classification/pass",
+        "trunk-admission/pass"
+      ],
+      "publishProof": "npm package readback for @sylphx/flow plus projection smoke evidence."
+    }
+  },
+  "adoption": {
+    "status": "baseline",
+    "gaps": [
+      {
+        "id": "admission-enforcement",
+        "description": "ADR-29 admission actions currently run in observe mode in the workflow; decide when this repo should enforce admission.",
+        "owner": "SylphxAI/flow",
+        "target": "before claiming full doctrine adoption"
+      },
+      {
+        "id": "projection-proof",
+        "description": "Make Codex/Claude/OpenCode projection smoke proof first-class release evidence.",
+        "owner": "SylphxAI/flow",
+        "target": "before claiming full package-release adoption"
+      }
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,10 @@
 # Flow Repository Instructions
 
+Engineering doctrine: https://github.com/SylphxAI/doctrine
+
+Before changing behavior, read `PROJECT.md`, `.doctrine/project.json`, this
+file, and the triggered standards in `SylphxAI/doctrine`.
+
 Flow is the public source of truth for Sylphx agent assets and runtime projections.
 
 Canonical agent behavior lives in `packages/flow/assets/`:

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -1,0 +1,60 @@
+# Flow Project
+
+Flow is a production agent-tooling repository for Sylphx agent assets and
+runtime projections. It owns canonical agent identities, standards, skills, and
+the `@sylphx/flow` CLI that projects those assets into supported AI coding
+tools.
+
+## Goals
+
+- Own canonical agent assets under `packages/flow/assets/`.
+- Own the Flow CLI, runtime projection logic, docs, package release workflow,
+  and admission workflow.
+- Keep agent identity, standards, and skills single-sourced and projected into
+  runtime-specific layouts without creating prompt islands.
+
+## Non-Goals
+
+- Do not own individual product repos' local project facts, deployment paths,
+  or customer-specific behavior.
+- Do not duplicate Builder identity, standards, or skills in runtime-specific
+  directories.
+- Do not treat source revert as complete recovery after package publish or
+  agent-runtime projection behavior is released.
+
+## Boundaries
+
+Owned contexts are canonical Flow assets, runtime projections, Flow CLI,
+package release, docs, and ADR-29 admission workflow. Product repos consume Flow
+through package exports, CLI commands, generated projections, and documented
+assets.
+
+Public surfaces:
+
+- Canonical assets under `packages/flow/assets/`.
+- CLI package `@sylphx/flow` in `packages/flow/package.json`.
+- Existing root agent adapter `AGENTS.md`.
+- Required contexts `risk-classification/pass` and `trunk-admission/pass`.
+
+## Delivery
+
+Current CI model: `adr29-admission`. Required branch contexts are
+`risk-classification/pass` and `trunk-admission/pass`.
+
+Release path: `.github/workflows/release.yml` calls the central reusable
+release workflow. Production proof must include admission contexts, CI
+fan-in/postsubmit proof, npm package readback, projection smoke tests, and docs
+readback.
+
+Recovery class: `forward-fix-only`, because published package versions and
+agent projection behavior cannot be fully undone by source revert.
+
+## References
+
+- Machine manifest: `.doctrine/project.json`
+- Root agent adapter: `AGENTS.md`
+- Canonical assets: `packages/flow/assets/`
+- Package: `packages/flow/package.json`
+- CI/admission: `.github/workflows/ci.yml`
+- Release: `.github/workflows/release.yml`
+- Doctrine: https://github.com/SylphxAI/doctrine


### PR DESCRIPTION
## Summary
- Add PROJECT.md and .doctrine/project.json for doctrine project-control-plane adoption.
- Update the existing AGENTS.md with doctrine/project manifest discovery pointers.
- Record Flow canonical-agent-asset boundaries, ADR-29 admission contexts, package release facts, and projection-proof gaps.

## Validation
- jq empty .doctrine/project.json
- git diff --check
- python3 /Users/kyle/.doctrine/scripts/project-control-plane-audit.py --local . --fail-on-drift --json -> PRESENT

## Scope
Docs/control-plane only. No runtime, CI, deployment, dependency, secret, or infrastructure changes.