### PR TITLE
docs: add ADR-81 selector facts

### DIFF
--- a/.doctrine/project.json
+++ b/.doctrine/project.json
@@ -5,6 +5,7 @@
     "name": "Flow",
     "lifecycle": "production",
     "layer": "tooling",
+    "policyPool": "agent-tool",
     "summary": "Flow is a production agent-tooling repository for canonical Sylphx agent assets, runtime projections, and the @sylphx/flow CLI.",
     "goals": [
       "Own canonical agent assets under packages/flow/assets/.",
@@ -97,6 +98,7 @@
   },
   "delivery": {
     "ciModel": "adr29-admission",
+    "deployable": false,
     "requiredContexts": ["risk-classification/pass", "trunk-admission/pass"],
     "deployPath": "Central reusable release workflow publishes the @sylphx/flow package from main release intent.",
     "productionProof": "Admission contexts, CI fan-in/postsubmit proof, npm package readback, projection smoke tests, and docs readback.",


### PR DESCRIPTION
## Summary
- Add `project.policyPool: agent-tool` and `delivery.deployable: false` to the project manifest.
- Make ADR-81 selector projection complete for the non-deployable Flow CLI/tooling package.

## Validation
- `python3 -m json.tool .doctrine/project.json`
- `python3 /Users/kyle/.doctrine/scripts/project-control-plane-audit.py --local . --fail-on-drift --json` -> `PRESENT`
- `python3 /Users/kyle/.doctrine/scripts/project-control-plane-audit.py --repo SylphxAI/flow --ref codex/adr81-selector-facts --fail-on-drift --json` -> `PRESENT`
- `python3 /Users/kyle/.doctrine/scripts/repo-selector-value-projection.py --repo SylphxAI/flow --ref codex/adr81-selector-facts --fail-on-blocked --json` -> `READY`
- `python3 /Users/kyle/.doctrine/scripts/package-release-conformance-audit.py --repo SylphxAI/flow --ref codex/adr81-selector-facts --json` -> `PARTIAL` (release-bot/OIDC/provenance/Changesets workflow evidence remains ADR-59 migration work, not an ADR-81 selector blocker)
- `git diff --check`