### PR TITLE
build(docs): deploy VitePress docs via platform Dockerfile (Bun -> Caddy)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+# syntax=docker/dockerfile:1.7@sha256:a57df69d0ea827fb7266491f2813635de6f17269be881f696fbfdf2d83dda33e
+# flow docs — VitePress static site built with Bun, served by Caddy.
+#
+# Mirrors the Sylphx Platform canonical `bun-static` buildpack template
+# (ADR-071 v2: package.json frontend build -> Caddy). flow is a Bun *workspace*
+# monorepo with a turbo.json, so the platform's `auto` buildpack routes it to a
+# node-server build instead of the static path — the docs site therefore
+# declares an explicit Dockerfile, the same escape hatch every first-party
+# Sylphx app uses. Base images are digest-pinned to match the platform's
+# base-images.json.
+
+ARG SOURCE_DATE_EPOCH
+
+FROM oven/bun:1.3-alpine@sha256:4de475389889577f346c636f956b42a5c31501b654664e9ae5726f94d7bb5349 AS builder
+WORKDIR /app
+# VitePress and its bundler live in devDependencies; keep the build stage in
+# development mode so they install.
+ENV NODE_ENV=development
+# Bun reconciles the frozen lockfile against every workspace manifest, so copy
+# the whole tree before install rather than just the root package.json.
+COPY . ./
+RUN --mount=type=cache,id=bun-flow-docs,target=/root/.bun/install/cache,sharing=locked \
+    bun install --frozen-lockfile
+RUN bun run docs:build
+
+FROM builder AS probe
+WORKDIR /app
+# L3 static-output probe — the build must produce a document Caddy can serve.
+RUN test -f docs/.vitepress/dist/index.html
+
+FROM caddy:2-alpine@sha256:834468128c7696cec0ceea6172f7d692daf645ae51983ca76e39da54a97c570d AS runner
+WORKDIR /srv
+ARG SOURCE_DATE_EPOCH
+# VitePress is a static MPA: resolve clean URLs to their `.html` file and
+# directory indexes, falling back to index.html for client-routed deep links.
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup \
+ && chown -R appuser:appgroup /srv \
+ && printf ':3000 {\n  root * /srv\n  encode gzip\n  try_files {path} {path}.html {path}/ /index.html\n  file_server\n}\n' > /etc/caddy/Caddyfile
+COPY --from=probe --chown=appuser:appgroup /app/docs/.vitepress/dist /srv
+USER appuser
+EXPOSE 3000
+CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]

--- a/sylphx.toml
+++ b/sylphx.toml
@@ -1,16 +1,29 @@
 version = "1"
 
 [project]
-name = "@sylphx/flow-monorepo"
+name = "Sylphx Flow"
 slug = "flow"
 org = "sylphx"
+default_env = "production"
+description = "Sylphx Flow documentation site (VitePress) — dogfoods the Sylphx Platform as the single source of truth for the docs deploy."
 
 [build]
-strategy = "auto"
-context = "docs"
+strategy = "dockerfile"
+dockerfile = "Dockerfile"
+context = "."
 
 [[services]]
 name = "web"
 type = "web"
-port = 80
-watch_paths = ["docs/**"]
+port = 3000
+watch_paths = [
+  "docs/**",
+  "package.json",
+  "bun.lock",
+  "Dockerfile",
+  "sylphx.toml",
+]
+
+[services.health]
+mode = "http"
+path = "/"


### PR DESCRIPTION
## What

flow's docs site (VitePress) is meant to deploy on the Sylphx Platform via `sylphx.toml`, but the committed manifest used `strategy = "auto"`, which **cannot** build it as a static site. Verified against the platform's actual buildpack source (`SylphxAI/platform` `packages/core/.../buildpack`):

- flow is a Bun **workspace** monorepo, and the `bun-static` path requires `globs.length === 0`;
- it has a `turbo.json`, so detection routes to `bun-turbo` (a node-server build, not static);
- the static-frontend detector needs an `index.html` at the source root — VitePress is markdown, `docs/.vitepress/dist/index.html` only exists *after* the build;
- `vitepress` isn't in the recognized build-tool set.

So `strategy = "auto"` would build the monorepo via turbo and try to run a node server that doesn't exist → no served docs.

## Change

Match how every first-party Sylphx app deploys (httphole, sylphx-ai, alpha-foundry all use `strategy = "dockerfile"`):

- **Add `Dockerfile`** mirroring the platform's canonical `bun-static` buildpack template (ADR-071 v2): Bun builds the VitePress site, Caddy serves the static output on `:3000`. Base images are digest-pinned to match the platform's `base-images.json`.
- **`sylphx.toml`** → `strategy = "dockerfile"`, a `web` service on port 3000, health path `/`, and `watch_paths` scoped to the docs inputs.

No runtime/app code change — deploy config only.

## Verification

Built and ran locally:

- `docker build` → succeeds (VitePress build + static-output probe pass).
- `GET /` → **HTTP 200**, `<title>Sylphx Flow</title>`, full VitePress homepage (hero, features, nav, real docs content).
- `GET /guide/getting-started` (clean URL) → **HTTP 200**.
- `GET /guide/getting-started.html` → **HTTP 200**.

## Sequencing

This is the enabling change for the single-source docs deploy. The production env tracks `main`, so this must land first; then the platform deploy is created + verified live; then the duplicate `vercel.json` is removed in #165.