### PR TITLE
docs: correct stale sylphxltd GitHub links to SylphxAI

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -385,7 +385,7 @@ cleanupHandler.register(async () => {
 
 ```bash
 # Clone and install
-git clone https://github.com/sylphxltd/flow.git
+git clone https://github.com/SylphxAI/flow.git
 cd flow
 bun install
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -124,7 +124,7 @@ Sylphx Flow is the universal orchestrator that eliminates the fragmentation of A
 ## Links
 
 - **npm**: https://www.npmjs.com/package/@sylphx/flow
-- **GitHub**: https://github.com/sylphxltd/flow
+- **GitHub**: https://github.com/SylphxAI/flow
 - **Documentation**: https://flow.sylphx.ai
 - **Twitter**: https://x.com/SylphxAI
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![downloads](https://img.shields.io/npm/dm/@sylphx/flow)](https://www.npmjs.com/package/@sylphx/flow)
 [![stars](https://img.shields.io/github/stars/SylphxAI/flow)](https://github.com/SylphxAI/flow)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![CI](https://github.com/sylphxltd/flow/actions/workflows/ci.yml/badge.svg)](https://github.com/sylphxltd/flow/actions/workflows/ci.yml)
+[![CI](https://github.com/SylphxAI/flow/actions/workflows/ci.yml/badge.svg)](https://github.com/SylphxAI/flow/actions/workflows/ci.yml)
 
 [Get Started](#-installation) • [Documentation](https://flow.sylphx.ai) • [npm](https://www.npmjs.com/package/@sylphx/flow) • [Twitter](https://x.com/SylphxAI)
 
@@ -828,12 +828,12 @@ sylphx-flow "process GitHub issues" --loop 600 --max-runs 100
 
 ### Essential Reading
 
-- **[Installation & Setup](https://github.com/sylphxltd/flow/wiki/Installation-&-Setup)** - Complete setup guide
-- **[Settings Guide](https://github.com/sylphxltd/flow/wiki/Settings-Guide)** - Master the settings nexus
-- **[MEP Design Philosophy](https://github.com/sylphxltd/flow/wiki/MEP-Design-Philosophy)** - Understand the paradigm shift
-- **[Technical Architecture](https://github.com/sylphxltd/flow/wiki/Technical-Architecture)** - Deep dive into Flow's internals
-- **[CLI Commands](https://github.com/sylphxltd/flow/wiki/CLI-Commands)** - Full command reference
-- **[Agent Framework](https://github.com/sylphxltd/flow/wiki/Agent-Framework)** - How agents work
+- **[Installation & Setup](https://github.com/SylphxAI/flow/wiki/Installation-&-Setup)** - Complete setup guide
+- **[Settings Guide](https://github.com/SylphxAI/flow/wiki/Settings-Guide)** - Master the settings nexus
+- **[MEP Design Philosophy](https://github.com/SylphxAI/flow/wiki/MEP-Design-Philosophy)** - Understand the paradigm shift
+- **[Technical Architecture](https://github.com/SylphxAI/flow/wiki/Technical-Architecture)** - Deep dive into Flow's internals
+- **[CLI Commands](https://github.com/SylphxAI/flow/wiki/CLI-Commands)** - Full command reference
+- **[Agent Framework](https://github.com/SylphxAI/flow/wiki/Agent-Framework)** - How agents work
 - **[Loop Mode Guide](./packages/flow/LOOP_MODE.md)** - Autonomous execution mastery
 
 ---

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -52,7 +52,7 @@ export default defineConfig({
     nav: [
       { text: 'Guide', link: '/guide/getting-started' },
       { text: 'Features', link: '/features/loop-mode' },
-      { text: 'GitHub', link: 'https://github.com/sylphxltd/flow' },
+      { text: 'GitHub', link: 'https://github.com/SylphxAI/flow' },
       { text: 'npm', link: 'https://www.npmjs.com/package/@sylphx/flow' },
     ],
 
@@ -84,7 +84,7 @@ export default defineConfig({
     },
 
     socialLinks: [
-      { icon: 'github', link: 'https://github.com/sylphxltd/flow' },
+      { icon: 'github', link: 'https://github.com/SylphxAI/flow' },
       { icon: 'npm', link: 'https://www.npmjs.com/package/@sylphx/flow' },
       { icon: 'twitter', link: 'https://x.com/SylphxAI' },
     ],

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -117,6 +117,6 @@ sylphx-flow "@task.txt"
 
 ## Need Help?
 
-- [GitHub Issues](https://github.com/sylphxltd/flow/issues)
+- [GitHub Issues](https://github.com/SylphxAI/flow/issues)
 - [Documentation](/)
 - [Examples](/guide/examples)

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ hero:
       link: /guide/getting-started
     - theme: alt
       text: View on GitHub
-      link: https://github.com/sylphxltd/flow
+      link: https://github.com/SylphxAI/flow
 
 features:
   - icon: 🔄
@@ -141,7 +141,7 @@ sylphx-flow "implement authentication"
 
 **Links:**
 - 📦 [npm Package](https://www.npmjs.com/package/@sylphx/flow)
-- 🐙 [GitHub Repository](https://github.com/sylphxltd/flow)
+- 🐙 [GitHub Repository](https://github.com/SylphxAI/flow)
 - 🐦 [Twitter/X @SylphxAI](https://x.com/SylphxAI)
 
 [Get Started →](/guide/getting-started)

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/sylphxltd/flow.git"
+    "url": "https://github.com/SylphxAI/flow.git"
   },
   "keywords": [
     "development",
@@ -25,12 +25,12 @@
     "ai-agents",
     "github-installation"
   ],
-  "author": "sylphxltd",
+  "author": "SylphxAI",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/sylphxltd/flow/issues"
+    "url": "https://github.com/SylphxAI/flow/issues"
   },
-  "homepage": "https://github.com/sylphxltd/flow#readme",
+  "homepage": "https://github.com/SylphxAI/flow#readme",
   "scripts": {
     "build": "turbo run build",
     "dev": "turbo run dev --parallel",

--- a/packages/flow/CHANGELOG.md
+++ b/packages/flow/CHANGELOG.md
@@ -2064,7 +2064,7 @@ Add comprehensive SaaS review command suite with parallel worker delegation.
   ## 🔗 Links
 
   - [Documentation](https://flow.sylphx.ai)
-  - [GitHub Repository](https://github.com/sylphxltd/flow)
+  - [GitHub Repository](https://github.com/SylphxAI/flow)
   - [Getting Started Guide](https://flow.sylphx.ai/guide/getting-started)
 
 ## 1.0.0

--- a/packages/flow/README.md
+++ b/packages/flow/README.md
@@ -33,7 +33,7 @@ sylphx-flow status
 
 ## Documentation
 
-See the [main repository](https://github.com/sylphxltd/flow) for full documentation.
+See the [main repository](https://github.com/SylphxAI/flow) for full documentation.
 
 ## License
 

--- a/packages/flow/package.json
+++ b/packages/flow/package.json
@@ -68,13 +68,13 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/sylphxltd/flow.git",
+    "url": "https://github.com/SylphxAI/flow.git",
     "directory": "packages/flow"
   },
   "bugs": {
-    "url": "https://github.com/sylphxltd/flow/issues"
+    "url": "https://github.com/SylphxAI/flow/issues"
   },
-  "homepage": "https://github.com/sylphxltd/flow#readme",
+  "homepage": "https://github.com/SylphxAI/flow#readme",
   "license": "MIT",
-  "author": "sylphxltd"
+  "author": "SylphxAI"
 }

--- a/wiki-pages/Agent-Framework.md
+++ b/wiki-pages/Agent-Framework.md
@@ -520,4 +520,4 @@ flow run "check code" --agent reviewer
 
 ---
 
-*Last Updated: 2025-10-30 | [Edit this page](https://github.com/sylphxltd/flow/wiki/Agent-Framework) | [Report Issues](https://github.com/sylphxltd/flow/issues)*
+*Last Updated: 2025-10-30 | [Edit this page](https://github.com/SylphxAI/flow/wiki/Agent-Framework) | [Report Issues](https://github.com/SylphxAI/flow/issues)*

--- a/wiki-pages/CLI-Commands.md
+++ b/wiki-pages/CLI-Commands.md
@@ -587,4 +587,4 @@ flow run "review for OWASP vulnerabilities" --agent reviewer
 
 ---
 
-*Last Updated: 2025-10-30 | [Edit this page](https://github.com/sylphxltd/flow/wiki/CLI-Commands) | [Report Issues](https://github.com/sylphxltd/flow/issues)*
+*Last Updated: 2025-10-30 | [Edit this page](https://github.com/SylphxAI/flow/wiki/CLI-Commands) | [Report Issues](https://github.com/SylphxAI/flow/issues)*

--- a/wiki-pages/Codebase-Search.md
+++ b/wiki-pages/Codebase-Search.md
@@ -645,4 +645,4 @@ cp .sylphx-flow/codebase.db backup/codebase-$(date +%Y%m%d).db
 
 ---
 
-*Last Updated: 2025-10-30 | [Edit this page](https://github.com/sylphxltd/flow/wiki/Codebase-Search) | [Report Issues](https://github.com/sylphxltd/flow/issues)*
+*Last Updated: 2025-10-30 | [Edit this page](https://github.com/SylphxAI/flow/wiki/Codebase-Search) | [Report Issues](https://github.com/SylphxAI/flow/issues)*

--- a/wiki-pages/Home.md
+++ b/wiki-pages/Home.md
@@ -361,9 +361,9 @@ flow run "document the API endpoints" --agent writer
 
 ## 🔗 Important Links
 
-- **[GitHub Repository](https://github.com/sylphxltd/flow)** - Source code and releases
-- **[Issue Tracker](https://github.com/sylphxltd/flow/issues)** - Report bugs or request features
-- **[Discussions](https://github.com/sylphxltd/flow/discussions)** - Community discussion
+- **[GitHub Repository](https://github.com/SylphxAI/flow)** - Source code and releases
+- **[Issue Tracker](https://github.com/SylphxAI/flow/issues)** - Report bugs or request features
+- **[Discussions](https://github.com/SylphxAI/flow/discussions)** - Community discussion
 
 ## 📊 System Status
 
@@ -382,4 +382,4 @@ Sylphx Flow isn't just another CLI tool or knowledge base. It's the **missing in
 
 ---
 
-*Last Updated: 2025-10-30 | [Edit this page](https://github.com/sylphxltd/flow/wiki/Home) | [Report Issues](https://github.com/sylphxltd/flow/issues)*
+*Last Updated: 2025-10-30 | [Edit this page](https://github.com/SylphxAI/flow/wiki/Home) | [Report Issues](https://github.com/SylphxAI/flow/issues)*

--- a/wiki-pages/Installation-&-Setup.md
+++ b/wiki-pages/Installation-&-Setup.md
@@ -29,7 +29,7 @@ For development or customization:
 
 ```bash
 # Clone the repository
-git clone https://github.com/sylphxltd/flow.git
+git clone https://github.com/SylphxAI/flow.git
 cd flow
 
 # Install dependencies (using Bun)
@@ -145,7 +145,7 @@ Configuration in `.claude/mcp.json`:
 }
 ```
 
-> **💡 Using latest unreleased version?** Replace `"@sylphx/flow"` with `"github:sylphxltd/flow"` in args.
+> **💡 Using latest unreleased version?** Replace `"@sylphx/flow"` with `"github:SylphxAI/flow"` in args.
 
 #### OpenCode
 Configuration in `opencode.jsonc`:
@@ -166,7 +166,7 @@ Configuration in `opencode.jsonc`:
 }
 ```
 
-> **💡 Using latest unreleased version?** Replace `"@sylphx/flow"` with `"github:sylphxltd/flow"` in command.
+> **💡 Using latest unreleased version?** Replace `"@sylphx/flow"` with `"github:SylphxAI/flow"` in command.
 
 ### Environment Variables
 
@@ -469,14 +469,14 @@ Once installation is complete:
 - **Performance**: Use `--disable-*` flags to disable unused MCP tools
 - **Debugging**: Use `--verbose` flag for detailed output
 - **Updates**: Pull latest npm version with `npx @sylphx/flow@latest`
-- **Bleeding Edge**: Use unreleased features with `npx github:sylphxltd/flow`
+- **Bleeding Edge**: Use unreleased features with `npx github:SylphxAI/flow`
 
 ## 📞 Getting Help
 
-- **[GitHub Issues](https://github.com/sylphxltd/flow/issues)** - Report bugs
-- **[Discussions](https://github.com/sylphxltd/flow/discussions)** - Ask questions
-- **[Wiki](https://github.com/sylphxltd/flow/wiki)** - Full documentation
+- **[GitHub Issues](https://github.com/SylphxAI/flow/issues)** - Report bugs
+- **[Discussions](https://github.com/SylphxAI/flow/discussions)** - Ask questions
+- **[Wiki](https://github.com/SylphxAI/flow/wiki)** - Full documentation
 
 ---
 
-*Last Updated: 2025-10-30 | [Edit this page](https://github.com/sylphxltd/flow/wiki/Installation-&-Setup) | [Report Issues](https://github.com/sylphxltd/flow/issues)*
+*Last Updated: 2025-10-30 | [Edit this page](https://github.com/SylphxAI/flow/wiki/Installation-&-Setup) | [Report Issues](https://github.com/SylphxAI/flow/issues)*

--- a/wiki-pages/Knowledge-Base.md
+++ b/wiki-pages/Knowledge-Base.md
@@ -663,4 +663,4 @@ flow mcp start
 
 ---
 
-*Last Updated: 2025-10-30 | [Edit this page](https://github.com/sylphxltd/flow/wiki/Knowledge-Base) | [Report Issues](https://github.com/sylphxltd/flow/issues)*
+*Last Updated: 2025-10-30 | [Edit this page](https://github.com/SylphxAI/flow/wiki/Knowledge-Base) | [Report Issues](https://github.com/SylphxAI/flow/issues)*

--- a/wiki-pages/MEP-Design-Philosophy.md
+++ b/wiki-pages/MEP-Design-Philosophy.md
@@ -537,4 +537,4 @@ Learn more about MEP implementation:
 
 ---
 
-*Last Updated: 2025-10-30 | [Edit this page](https://github.com/sylphxltd/flow/wiki/MEP-Design-Philosophy) | [Report Issues](https://github.com/sylphxltd/flow/issues)*
+*Last Updated: 2025-10-30 | [Edit this page](https://github.com/SylphxAI/flow/wiki/MEP-Design-Philosophy) | [Report Issues](https://github.com/SylphxAI/flow/issues)*

--- a/wiki-pages/Technical-Architecture.md
+++ b/wiki-pages/Technical-Architecture.md
@@ -704,4 +704,4 @@ Learn more about the implementation:
 
 ---
 
-*Last Updated: 2025-10-30 | [Edit this page](https://github.com/sylphxltd/flow/wiki/Technical-Architecture) | [Report Issues](https://github.com/sylphxltd/flow/issues)*
+*Last Updated: 2025-10-30 | [Edit this page](https://github.com/SylphxAI/flow/wiki/Technical-Architecture) | [Report Issues](https://github.com/SylphxAI/flow/issues)*


### PR DESCRIPTION
## What

The GitHub org renamed from `sylphxltd` to `SylphxAI` (`github.com/sylphxltd` → 404; `github.com/sylphxltd/flow` now only resolves via GitHub's owner-redirect to `SylphxAI/flow`). This updates the stale references to the canonical owner:

- `docs/.vitepress/config.ts` — nav GitHub link + social GitHub link
- `package.json` — `repository.url`, `bugs.url`, `homepage`

No behaviour change; links now point at `SylphxAI/flow` directly instead of relying on the redirect.

## Note

This also serves as the first push to a docs/config watch_path on `main` since flow's production environment was connected on the Sylphx Platform, so it triggers the initial platform docs build/deploy (the `connect` step does not itself fire a build).